### PR TITLE
fix am vs pm error for hour = 12 times

### DIFF
--- a/timedisplay.php
+++ b/timedisplay.php
@@ -187,11 +187,12 @@
 
 <p> <?php 
 	if (!strcmp("time", $_POST['timevsgps'])) {
-	    if (!strcmp("pm", $_POST['type'])){
-		$hour = (int)$_POST['hour'] + 12;
-	    } else {
-		$hour = $_POST['hour'];
-	    }
+	    $hour = $_POST['hour'];
+            if (!strcmp("pm", $_POST['type']) && $hour<12){
+                $hour = $hour + 12;
+            } elseif (!strcmp("am", $_POST['type']) && $hour==12){
+                $hour = 0;
+            }
             $month = $_POST['month']; 
 	    $day = $_POST['day'];
 	    $year = $_POST['year'];


### PR DESCRIPTION
handle the conversion between am/pm and 24 hour time when the hour is 12 so that 12 am is midnight and 12 pm is noon